### PR TITLE
説明文が空文字でも更新できるように修正

### DIFF
--- a/autobackup/update_request.go
+++ b/autobackup/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name                    *string                `service:",omitempty" validate:"omitempty,min=1"`
-	Description             *string                `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description             *string                `service:",omitempty" validate:"omitempty,max=512"`
 	Tags                    *types.Tags            `service:",omitempty"`
 	IconID                  *types.ID              `service:",omitempty"`
 	BackupSpanWeekdays      *[]types.EDayOfTheWeek `service:",omitempty"`

--- a/autobackup/update_request.go
+++ b/autobackup/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name                    *string                `service:",omitempty" validate:"omitempty,min=1"`
-	Description             *string                `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description             *string                `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags                    *types.Tags            `service:",omitempty"`
 	IconID                  *types.ID              `service:",omitempty"`
 	BackupSpanWeekdays      *[]types.EDayOfTheWeek `service:",omitempty"`

--- a/autoscale/update_request.go
+++ b/autoscale/update_request.go
@@ -25,7 +25,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/autoscale/update_request.go
+++ b/autoscale/update_request.go
@@ -25,7 +25,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/bridge/update_request.go
+++ b/bridge/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name        *string `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string `service:",omitempty" validate:"omitempty,min=0,max=512"`
 }
 
 func (req *UpdateRequest) Validate() error {

--- a/bridge/update_request.go
+++ b/bridge/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name        *string `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string `service:",omitempty" validate:"omitempty,max=512"`
 }
 
 func (req *UpdateRequest) Validate() error {

--- a/cdrom/update_request.go
+++ b/cdrom/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 }

--- a/cdrom/update_request.go
+++ b/cdrom/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 }

--- a/certificateauthority/update_request.go
+++ b/certificateauthority/update_request.go
@@ -29,7 +29,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/certificateauthority/update_request.go
+++ b/certificateauthority/update_request.go
@@ -29,7 +29,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/containerregistry/update_request.go
+++ b/containerregistry/update_request.go
@@ -28,7 +28,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name          *string                              `service:",omitempty" validate:"omitempty,min=1"`
-	Description   *string                              `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description   *string                              `service:",omitempty" validate:"omitempty,max=512"`
 	Tags          *types.Tags                          `service:",omitempty"`
 	IconID        *types.ID                            `service:",omitempty"`
 	AccessLevel   *types.EContainerRegistryAccessLevel `service:",omitempty"`

--- a/containerregistry/update_request.go
+++ b/containerregistry/update_request.go
@@ -28,7 +28,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name          *string                              `service:",omitempty" validate:"omitempty,min=1"`
-	Description   *string                              `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description   *string                              `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags          *types.Tags                          `service:",omitempty"`
 	IconID        *types.ID                            `service:",omitempty"`
 	AccessLevel   *types.EContainerRegistryAccessLevel `service:",omitempty"`

--- a/database/update_request.go
+++ b/database/update_request.go
@@ -31,7 +31,7 @@ type UpdateRequest struct {
 	ID   types.ID `validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/database/update_request.go
+++ b/database/update_request.go
@@ -31,7 +31,7 @@ type UpdateRequest struct {
 	ID   types.ID `validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/disk/update_request.go
+++ b/disk/update_request.go
@@ -29,7 +29,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name          *string                `service:",omitempty" validate:"omitempty,min=1"`
-	Description   *string                `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description   *string                `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags          *types.Tags            `service:",omitempty"`
 	IconID        *types.ID              `service:",omitempty"`
 	Connection    *types.EDiskConnection `service:",omitempty"`

--- a/disk/update_request.go
+++ b/disk/update_request.go
@@ -29,7 +29,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name          *string                `service:",omitempty" validate:"omitempty,min=1"`
-	Description   *string                `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description   *string                `service:",omitempty" validate:"omitempty,max=512"`
 	Tags          *types.Tags            `service:",omitempty"`
 	IconID        *types.ID              `service:",omitempty"`
 	Connection    *types.EDiskConnection `service:",omitempty"`

--- a/dns/update_request.go
+++ b/dns/update_request.go
@@ -24,7 +24,7 @@ import (
 type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
-	Description  *string         `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description  *string         `service:",omitempty" validate:"omitempty,max=512"`
 	Tags         *types.Tags     `service:",omitempty"`
 	IconID       *types.ID       `service:",omitempty"`
 	Records      iaas.DNSRecords `service:",omitempty,dive"`

--- a/dns/update_request.go
+++ b/dns/update_request.go
@@ -24,7 +24,7 @@ import (
 type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
-	Description  *string         `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description  *string         `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags         *types.Tags     `service:",omitempty"`
 	IconID       *types.ID       `service:",omitempty"`
 	Records      iaas.DNSRecords `service:",omitempty,dive"`

--- a/enhanceddb/update_request.go
+++ b/enhanceddb/update_request.go
@@ -27,7 +27,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/enhanceddb/update_request.go
+++ b/enhanceddb/update_request.go
@@ -27,7 +27,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/esme/update_request.go
+++ b/esme/update_request.go
@@ -25,7 +25,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 }

--- a/esme/update_request.go
+++ b/esme/update_request.go
@@ -25,7 +25,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 }

--- a/gslb/update_request.go
+++ b/gslb/update_request.go
@@ -25,7 +25,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name               *string               `service:",omitempty" validate:"omitempty,min=1"`
-	Description        *string               `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description        *string               `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags               *types.Tags           `service:",omitempty"`
 	IconID             *types.ID             `service:",omitempty"`
 	HealthCheck        *iaas.GSLBHealthCheck `service:",omitempty"`

--- a/gslb/update_request.go
+++ b/gslb/update_request.go
@@ -25,7 +25,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name               *string               `service:",omitempty" validate:"omitempty,min=1"`
-	Description        *string               `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description        *string               `service:",omitempty" validate:"omitempty,max=512"`
 	Tags               *types.Tags           `service:",omitempty"`
 	IconID             *types.ID             `service:",omitempty"`
 	HealthCheck        *iaas.GSLBHealthCheck `service:",omitempty"`

--- a/internet/update_request.go
+++ b/internet/update_request.go
@@ -29,7 +29,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name          *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description   *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description   *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags          *types.Tags `service:",omitempty"`
 	IconID        *types.ID   `service:",omitempty"`
 	BandWidthMbps *int        `service:",omitempty"`

--- a/internet/update_request.go
+++ b/internet/update_request.go
@@ -29,7 +29,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name          *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description   *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description   *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags          *types.Tags `service:",omitempty"`
 	IconID        *types.ID   `service:",omitempty"`
 	BandWidthMbps *int        `service:",omitempty"`

--- a/loadbalancer/update_request.go
+++ b/loadbalancer/update_request.go
@@ -29,7 +29,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name               *string                              `service:",omitempty" validate:"omitempty,min=1"`
-	Description        *string                              `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description        *string                              `service:",omitempty" validate:"omitempty,max=512"`
 	Tags               *types.Tags                          `service:",omitempty"`
 	IconID             *types.ID                            `service:",omitempty"`
 	VirtualIPAddresses *iaas.LoadBalancerVirtualIPAddresses `service:",omitempty"`

--- a/loadbalancer/update_request.go
+++ b/loadbalancer/update_request.go
@@ -29,7 +29,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name               *string                              `service:",omitempty" validate:"omitempty,min=1"`
-	Description        *string                              `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description        *string                              `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags               *types.Tags                          `service:",omitempty"`
 	IconID             *types.ID                            `service:",omitempty"`
 	VirtualIPAddresses *iaas.LoadBalancerVirtualIPAddresses `service:",omitempty"`

--- a/localrouter/update_request.go
+++ b/localrouter/update_request.go
@@ -27,7 +27,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name         *string                         `service:",omitempty" validate:"omitempty,min=1"`
-	Description  *string                         `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description  *string                         `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags         *types.Tags                     `service:",omitempty"`
 	IconID       *types.ID                       `service:",omitempty"`
 	Switch       *iaas.LocalRouterSwitch         `service:",omitempty"`

--- a/localrouter/update_request.go
+++ b/localrouter/update_request.go
@@ -27,7 +27,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name         *string                         `service:",omitempty" validate:"omitempty,min=1"`
-	Description  *string                         `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description  *string                         `service:",omitempty" validate:"omitempty,max=512"`
 	Tags         *types.Tags                     `service:",omitempty"`
 	IconID       *types.ID                       `service:",omitempty"`
 	Switch       *iaas.LocalRouterSwitch         `service:",omitempty"`

--- a/nfs/update_request.go
+++ b/nfs/update_request.go
@@ -29,7 +29,7 @@ type UpdateRequest struct {
 	ID   types.ID `validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 }

--- a/nfs/update_request.go
+++ b/nfs/update_request.go
@@ -29,7 +29,7 @@ type UpdateRequest struct {
 	ID   types.ID `validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 }

--- a/packetfilter/update_request.go
+++ b/packetfilter/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name                   *string                         `service:",omitempty" validate:"omitempty,min=1"`
-	Description            *string                         `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description            *string                         `service:",omitempty" validate:"omitempty,max=512"`
 	Expression             *[]*iaas.PacketFilterExpression `service:",omitempty"`
 	OriginalExpressionHash string
 }

--- a/packetfilter/update_request.go
+++ b/packetfilter/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name                   *string                         `service:",omitempty" validate:"omitempty,min=1"`
-	Description            *string                         `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description            *string                         `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Expression             *[]*iaas.PacketFilterExpression `service:",omitempty"`
 	OriginalExpressionHash string
 }

--- a/privatehost/update_request.go
+++ b/privatehost/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 }

--- a/privatehost/update_request.go
+++ b/privatehost/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 }

--- a/proxylb/update_request.go
+++ b/proxylb/update_request.go
@@ -25,7 +25,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name                 *string                           `service:",omitempty" validate:"omitempty,min=1"`
-	Description          *string                           `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description          *string                           `service:",omitempty" validate:"omitempty,max=512"`
 	Tags                 *types.Tags                       `service:",omitempty"`
 	IconID               *types.ID                         `service:",omitempty"`
 	Plan                 *types.EProxyLBPlan               `service:",omitempty" validate:"omitempty,oneof=100 500 1000 5000 10000 50000 100000 400000"`

--- a/proxylb/update_request.go
+++ b/proxylb/update_request.go
@@ -25,7 +25,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name                 *string                           `service:",omitempty" validate:"omitempty,min=1"`
-	Description          *string                           `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description          *string                           `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags                 *types.Tags                       `service:",omitempty"`
 	IconID               *types.ID                         `service:",omitempty"`
 	Plan                 *types.EProxyLBPlan               `service:",omitempty" validate:"omitempty,oneof=100 500 1000 5000 10000 50000 100000 400000"`

--- a/sim/update_request.go
+++ b/sim/update_request.go
@@ -28,7 +28,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/sim/update_request.go
+++ b/sim/update_request.go
@@ -28,7 +28,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/simplemonitor/update_request.go
+++ b/simplemonitor/update_request.go
@@ -24,7 +24,7 @@ import (
 type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
-	Description        *string                        `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description        *string                        `service:",omitempty" validate:"omitempty,max=512"`
 	Tags               *types.Tags                    `service:",omitempty"`
 	IconID             *types.ID                      `service:",omitempty"`
 	MaxCheckAttempts   *int                           `service:",omitempty"`

--- a/simplemonitor/update_request.go
+++ b/simplemonitor/update_request.go
@@ -24,7 +24,7 @@ import (
 type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
-	Description        *string                        `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description        *string                        `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags               *types.Tags                    `service:",omitempty"`
 	IconID             *types.ID                      `service:",omitempty"`
 	MaxCheckAttempts   *int                           `service:",omitempty"`

--- a/sshkey/update_request.go
+++ b/sshkey/update_request.go
@@ -25,7 +25,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string `service:",omitempty" validate:"omitempty,max=512"`
 }
 
 func (req *UpdateRequest) Validate() error {

--- a/sshkey/update_request.go
+++ b/sshkey/update_request.go
@@ -25,7 +25,7 @@ type UpdateRequest struct {
 	ID types.ID `service:"-" validate:"required"`
 
 	Name        *string `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string `service:",omitempty" validate:"omitempty,min=0,max=512"`
 }
 
 func (req *UpdateRequest) Validate() error {

--- a/swytch/update_request.go
+++ b/swytch/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name           *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description    *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description    *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags           *types.Tags `service:",omitempty"`
 	IconID         *types.ID   `service:",omitempty"`
 	NetworkMaskLen *int        `service:",omitempty"`

--- a/swytch/update_request.go
+++ b/swytch/update_request.go
@@ -26,7 +26,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name           *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description    *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description    *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags           *types.Tags `service:",omitempty"`
 	IconID         *types.ID   `service:",omitempty"`
 	NetworkMaskLen *int        `service:",omitempty"`

--- a/vpcrouter/update_request.go
+++ b/vpcrouter/update_request.go
@@ -30,7 +30,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/vpcrouter/update_request.go
+++ b/vpcrouter/update_request.go
@@ -30,7 +30,7 @@ type UpdateRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/vpcrouter/update_standard_request.go
+++ b/vpcrouter/update_standard_request.go
@@ -30,7 +30,7 @@ type UpdateStandardRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=1,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 

--- a/vpcrouter/update_standard_request.go
+++ b/vpcrouter/update_standard_request.go
@@ -30,7 +30,7 @@ type UpdateStandardRequest struct {
 	ID   types.ID `service:"-" validate:"required"`
 
 	Name        *string     `service:",omitempty" validate:"omitempty,min=1"`
-	Description *string     `service:",omitempty" validate:"omitempty,min=0,max=512"`
+	Description *string     `service:",omitempty" validate:"omitempty,max=512"`
 	Tags        *types.Tags `service:",omitempty"`
 	IconID      *types.ID   `service:",omitempty"`
 


### PR DESCRIPTION
## 説明

DNSゾーンの更新をしようとしたのですが、任意である説明文が空文字(`""`)であるとバリデーションに引っかかってしまいます。
Descriptionフィールドに`nil`を渡すと通るのですが、Read/Findから帰ってくる値には空文字のときがあるので空文字も許容していただきたいです。

```
1 error occurred:
  * Description: min=1
```

## 改善内容

Descriptionフィールドのバリデーションの最小文字数を`1`から`0`へ変更しました。
(DNSだけでなく他機能も修正しました)

## 確認したこと

- [x] 空文字でもリクエストが送れることを確認