### PR TITLE
FPTサーバ接続時にTLS 1.2を利用

### DIFF
--- a/archive/builder/blank_archive_builder.go
+++ b/archive/builder/blank_archive_builder.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/sacloud/ftps"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/iaas-service-go/ftps"
 	"github.com/sacloud/packages-go/size"
 )
 

--- a/archive/download_service.go
+++ b/archive/download_service.go
@@ -20,9 +20,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/sacloud/ftps"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/iaas-service-go/ftps"
 )
 
 func (s *Service) Download(req *DownloadRequest) error {

--- a/archive/upload_service.go
+++ b/archive/upload_service.go
@@ -20,9 +20,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/sacloud/ftps"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/iaas-service-go/ftps"
 )
 
 func (s *Service) Upload(req *UploadRequest) error {

--- a/cdrom/create_service.go
+++ b/cdrom/create_service.go
@@ -20,8 +20,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/sacloud/ftps"
 	"github.com/sacloud/iaas-api-go"
+	"github.com/sacloud/iaas-service-go/ftps"
 	"github.com/sacloud/packages-go/size"
 )
 

--- a/cdrom/download_service.go
+++ b/cdrom/download_service.go
@@ -20,9 +20,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/sacloud/ftps"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/iaas-service-go/ftps"
 )
 
 func (s *Service) Download(req *DownloadRequest) error {

--- a/cdrom/upload_service.go
+++ b/cdrom/upload_service.go
@@ -20,9 +20,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/sacloud/ftps"
 	"github.com/sacloud/iaas-api-go"
 	"github.com/sacloud/iaas-api-go/types"
+	"github.com/sacloud/iaas-service-go/ftps"
 )
 
 func (s *Service) Upload(req *UploadRequest) error {

--- a/ftps/ftps.go
+++ b/ftps/ftps.go
@@ -1,0 +1,28 @@
+// Copyright 2022-2023 The sacloud/iaas-service-go Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ftps
+
+import (
+	"crypto/tls"
+
+	"github.com/sacloud/ftps"
+)
+
+func NewClient(user, password, hostName string) *ftps.Client {
+	return ftps.NewClientWithTLSConfig(user, password, hostName, &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec
+		MaxVersion:         tls.VersionTLS12,
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sacloud/iaas-service-go
 go 1.20
 
 require (
-	github.com/sacloud/ftps v1.1.0
+	github.com/sacloud/ftps v1.2.0
 	github.com/sacloud/iaas-api-go v1.10.0
 	github.com/sacloud/packages-go v0.0.8
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUA
 github.com/rwtodd/Go.Sed v0.0.0-20210816025313-55464686f9ef/go.mod h1:8AEUvGVi2uQ5b24BIhcr0GCcpd/RNAFWaN2CJFrWIIQ=
 github.com/sacloud/api-client-go v0.2.7 h1:u8e8UdvYtpLiqTsmbJ6fLXceTievQ104ZKZb7VQ5wq8=
 github.com/sacloud/api-client-go v0.2.7/go.mod h1:PwvwOLcCdGLWK7MS/yawllp8XI60kRzzA4tg14u1zQY=
-github.com/sacloud/ftps v1.1.0 h1:cYv+b6qhrIT8msfx64XXRJzbv5S+Dqwb/rXa5Y641XA=
-github.com/sacloud/ftps v1.1.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
+github.com/sacloud/ftps v1.2.0 h1:7UlSWd7cnm1J+sANz7IiBV9ffVcS+4g6ZV5UHVVbvaw=
+github.com/sacloud/ftps v1.2.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
 github.com/sacloud/go-http v0.1.5 h1:Ov1Vr4Olf0P+FG2okmpSaftCQnyHoCKZtbCC6RlNZUI=
 github.com/sacloud/go-http v0.1.5/go.mod h1:jlBMvkz4PuAelewTMOVzNQVuI2EyBYJGHS7nub79Yh0=
 github.com/sacloud/iaas-api-go v1.10.0 h1:dBXqyUr3bQR0hQppIesFD4MbFernmqG+5wl6RWUNoxg=


### PR DESCRIPTION
TLS 1.3接続時のエラーを回避するためにsacloud/ftps v1.2を利用しつつtls.Configを指定することでTLS 1.2を利用する