### PR TITLE
Ubuntu 20.04を廃止 & latestと24.04を追加

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-22.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-latest, ubuntu-24.04, ubuntu-22.04]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

日次のCIがエラーになっていることへの対応、Ubuntu 20.04を除去し代わりにlatestと24.04を追加する。

### ドキュメントの変更は必要ですか？

no