### PR TITLE
fixes missing SSHKeys assignment in edit request

### DIFF
--- a/disk/builder/edit_request.go
+++ b/disk/builder/edit_request.go
@@ -106,6 +106,7 @@ func (u *UnixEditRequest) prepareDiskEditParameter(ctx context.Context, client *
 			ID: id,
 		})
 	}
+	editReq.SSHKeys = sshKeys
 
 	// startup script
 	var notes []*iaas.DiskEditNote


### PR DESCRIPTION
### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

#152 でSSH公開鍵の生成機能の取り下げを行った際に既存の処理に必要な行を削除してしまっていた。
具体的にはSSH公開鍵をディスクの修正パラメータに反映(アサイン)する部分が消えていた。

このPRでは消してしまった行を復活させた。

### ドキュメントの変更は必要ですか？

no