### PR TITLE
fix: pass zone to NFS plan query functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,15 @@
 module github.com/sacloud/iaas-service-go
 
-go 1.25.8
+go 1.25.0
+
+toolchain go1.26.2
 
 require (
 	github.com/jlaffaye/ftp v0.2.0
 	github.com/sacloud/api-client-go v0.3.5
-	github.com/sacloud/iaas-api-go v1.27.0
+	github.com/sacloud/iaas-api-go v1.28.0
 	github.com/sacloud/iam-api-go v0.3.0
-	github.com/sacloud/packages-go v0.0.13
+	github.com/sacloud/packages-go v0.1.0
 	github.com/sacloud/saclient-go v0.3.7
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -79,12 +79,12 @@ github.com/sacloud/api-client-go v0.3.5 h1:0ALibvbC+6MBhN7t61k+RhguhiEQ8+NejqBjq
 github.com/sacloud/api-client-go v0.3.5/go.mod h1:akdcCOl6wszywa0YQ5X8cMnNgWTm+7N4EneODTdiH48=
 github.com/sacloud/go-http v0.1.9 h1:Xa5PY8/pb7XWhwG9nAeXSrYXPbtfBWqawgzxD5co3VE=
 github.com/sacloud/go-http v0.1.9/go.mod h1:DpDG+MSyxYaBwPJ7l3aKLMzwYdTVtC5Bo63HActcgoE=
-github.com/sacloud/iaas-api-go v1.27.0 h1:nFZaF1eQ2UUciiOD7SWMH6yAoNr481+KJIo4pEVH5CA=
-github.com/sacloud/iaas-api-go v1.27.0/go.mod h1:P+vb3H4b3WmV28WX9qazXp7ESWRkPu9xBTgMKsmQEhU=
+github.com/sacloud/iaas-api-go v1.28.0 h1:QBSKrZwy7GivhF+npAU2BAYnKAhq8AGrjNoxmqfNNnc=
+github.com/sacloud/iaas-api-go v1.28.0/go.mod h1:VsW1NC1FPmwRjQRb3npmaOsI2hMtG813HjlomzaLr0U=
 github.com/sacloud/iam-api-go v0.3.0 h1:t7dav2jRnn2DhSg5u9tpyoltFpastnTR/jNZ3OsW6fU=
 github.com/sacloud/iam-api-go v0.3.0/go.mod h1:uKYamf4LfU7gDkWS7MN2xFaiHr4g0DcAOGyr2fNSuL8=
-github.com/sacloud/packages-go v0.0.13 h1:9ADnqKEr2JTCmC5TZPXjrJ/aQBg6QjE3dJlKVy/NCag=
-github.com/sacloud/packages-go v0.0.13/go.mod h1:reS4C3Y1iA18J7kE8GVIPrvI9SU1ujm1v5/ASpiRvSg=
+github.com/sacloud/packages-go v0.1.0 h1:rixWcvkVUI4kX6UYTFJbQgZIoBoNhN48MivHIu3aYq0=
+github.com/sacloud/packages-go v0.1.0/go.mod h1:ntmPnjF8+mGWNtxgBmO0CrLphUlmRkpy+DztjlECp8M=
 github.com/sacloud/saclient-go v0.3.7 h1:LAkOHStYxIKoypiaarhNOwm/JPuubgoKuOSXZWEerbc=
 github.com/sacloud/saclient-go v0.3.7/go.mod h1:h8ATHi9AnQhOxYNm8mbVWyM9/2569PPESIGwAc2SNg4=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=

--- a/includes/go/common.mk
+++ b/includes/go/common.mk
@@ -19,7 +19,7 @@ COPYRIGHT_YEAR          ?= 2023
 COPYRIGHT_FILES         ?= $$(find . -name "*.go" -print | grep -v "/vendor/")
 GO                      ?= go
 DEFAULT_GOALS           ?= fmt set-license go-licenses-check goimports lint test
-GOLANG_CI_LINT_VERSION  ?= v2.7.2
+GOLANG_CI_LINT_VERSION  ?= v2.11.4
 TEXTLINT_ACTION_VERSION ?= v0.1.0
 
 .DEFAULT_GOAL = default

--- a/nfs/builder/builder.go
+++ b/nfs/builder/builder.go
@@ -54,7 +54,7 @@ func (b *Builder) Build(ctx context.Context) (*iaas.NFS, error) {
 }
 
 func (b *Builder) findPlanID(ctx context.Context) (types.ID, error) {
-	return query.FindNFSPlanID(ctx, iaas.NewNoteOp(b.Caller), b.Plan, b.Size)
+	return query.FindNFSPlanID(ctx, iaas.NewNoteOp(b.Caller), b.Zone, b.Plan, b.Size)
 }
 
 func (b *Builder) create(ctx context.Context) (*iaas.NFS, error) {

--- a/nfs/update_request.go
+++ b/nfs/update_request.go
@@ -46,7 +46,7 @@ func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller iaas.APICalle
 	}
 
 	// find plan
-	plan, err := query.GetNFSPlanInfo(ctx, iaas.NewNoteOp(caller), current.PlanID)
+	plan, err := query.GetNFSPlanInfo(ctx, iaas.NewNoteOp(caller), req.Zone, current.PlanID)
 	if err != nil {
 		return nil, err
 	}

--- a/setup/setup_test.go
+++ b/setup/setup_test.go
@@ -50,7 +50,7 @@ func TestRetryableSetup(t *testing.T) {
 				nfsOp := iaas.NewNFSOp(caller)
 				nfsSetup := &RetryableSetup{
 					Create: func(ctx context.Context, zone string) (accessor.ID, error) {
-						nfsPlanID, err := query.FindNFSPlanID(ctx, iaas.NewNoteOp(caller), types.NFSPlans.HDD, types.NFSHDDSizes.Size100GB)
+						nfsPlanID, err := query.FindNFSPlanID(ctx, iaas.NewNoteOp(caller), testZone, types.NFSPlans.HDD, types.NFSHDDSizes.Size100GB)
 						if err != nil {
 							return nil, err
 						}


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

iaas-api-goの更新でNFSプラン関連のクエリ関数（`FindNFSPlanID`, `GetNFSPlanInfo`）呼び出しのAPI仕様変更が行われました。これに対応するためにzone 引数を追加しました。  
対象は `nfs/builder`, `nfs/update_request`, `setup/setup_test` の3箇所です。

また、今回からiaas-api-goのgo.modでのgoディレクティブが `go 1.25.0`にダウングレードされているため合わせました

### ドキュメントの変更は必要ですか？

不要